### PR TITLE
Remove unnecessary path to mocha bin from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --ui mocha-fibers --recursive -R spec --require test/test_helper.js"
+    "test": "mocha --ui mocha-fibers --recursive -R spec --require test/test_helper.js"
   }
 }


### PR DESCRIPTION
`npm test` automatically adds `node_modules/.bin` to PATH when executing the command.