### PR TITLE
Add binary readers and writers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 
 npm-debug.log
+test/components/goodbye-world.txt

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ These tests (except for `fbptestws`) can be run sequentially by running `fbptest
  
 # Components
 
+- `breader` - reads from a binary file specified by FILE IIP and sends one IP per byte in the file. Starts sending IPs as soon as first byte is read.
+- `bwriter` - takes a stream of IPs containing bytes and writes them to a file from its FILE IIP. Starts writing as soon as the first IP comes in.
 - `collate` - collates from 1 to any number of sorted input streams, generating merged stream with bracket IPs inserted (sort fields assumed to be contiguous starting at 1st byte; all streams assumed to be sorted on same fields, in ascending sequence) 
 - `concat`  - concatenates all the streams that are sent to its array input port (size determined in network definition) 
 - `copier`  - copies its input stream to its output stream

--- a/components/breader.js
+++ b/components/breader.js
@@ -7,7 +7,7 @@
  */
 
 var fs = require('fs');
-var IP = require('jsfbp/core/IP');
+var IP = require('../core/IP');
 var trace = require('../core/trace');
 
 var READ_SIZE = 4;

--- a/components/breader.js
+++ b/components/breader.js
@@ -1,0 +1,74 @@
+"use strict";
+/**
+ * This component reads a file and sends one IP per byte of the file to OUT
+ * The IPs are streamed out as the file is read, so the network can start flowing as soon as reading begins.
+ * This should make things a lot faster (and less memory hungry) for large files.
+ * File name is given by the FILE inport
+ */
+
+var fs = require('fs');
+var IP = require('jsfbp/core/IP');
+var trace = require('../core/trace');
+
+var READ_SIZE = 4;
+
+module.exports = function reader(runtime) {
+  var inport = this.openInputPort('FILE');
+  var ip = inport.receive();
+  var fname = ip.contents;
+  this.dropIP(ip);
+
+  trace("Opening file: " + fname);
+  var openResult = runtime.runAsyncCallback(openFile(fname, 'r', this));
+
+  var fileDescriptor = openResult[1];
+  if (fileDescriptor == undefined) {
+    console.log("OPEN error: " + openResult);
+    return;
+  }
+  trace("Got fd: " + fileDescriptor);
+
+  var outport = this.openOutputPort('OUT');
+  trace("Starting read");
+  outport.send(this.createIPBracket(IP.OPEN));
+  readFile(runtime, this, fileDescriptor, outport);
+
+  fs.closeSync(fileDescriptor);
+  outport.send(this.createIPBracket(IP.CLOSE));
+
+};
+
+function readFile(runtime, proc, fileDescriptor, outport) {
+  do {
+    var readResult = runtime.runAsyncCallback(readData(fileDescriptor, READ_SIZE));
+    if (readResult[0]) {
+      console.error(readResult[0]);
+      return;
+    }
+    var bytesRead = readResult[1];
+    var data = readResult[2];
+
+    for (var i = 0; i < bytesRead; i++) {
+      var byte = data[i];
+      trace("Got byte: " + byte);
+      outport.send(proc.createIP(byte));
+    }
+  } while (bytesRead === READ_SIZE);
+}
+
+function openFile(path, flags) {
+  return function (done) {
+    fs.open(path, flags, function (err, fd) {
+      done([err, fd]);
+    });
+  }
+}
+
+function readData(fd, size) {
+  return function (done) {
+    fs.read(fd,new Buffer(size), 0, size, null, function(err, bytesRead, buffer) {
+      done([err, bytesRead, buffer]);
+    });
+  }
+}
+

--- a/components/bwriter.js
+++ b/components/bwriter.js
@@ -1,0 +1,79 @@
+"use strict";
+/**
+ * This component writes a binary file based on IPs that it receives.
+ * The IPs are written out as the IPs come in, so the writing goes in pace with data flowing in.
+ * This should make things a lot faster (and less memory hungry) for large files.
+ * File name is given by the FILE inport
+ */
+
+var fs = require('fs');
+var IP = require('jsfbp/core/IP');
+var trace = require('../core/trace');
+
+module.exports = function reader(runtime) {
+  var filePort = this.openInputPort('FILE');
+  var ip = filePort.receive();
+  var fname = ip.contents;
+  this.dropIP(ip);
+
+  trace("Opening file: " + fname);
+  var openResult = runtime.runAsyncCallback(openFile(fname, 'w', this));
+
+  var fileDescriptor = openResult[1];
+  if (fileDescriptor == undefined) {
+    console.log("OPEN error: " + openResult);
+    return;
+  }
+  trace("Got fd: " + fileDescriptor);
+
+  var inPort = this.openInputPort('IN');
+  trace("Starting read");
+  var bracket = inPort.receive();
+  if(bracket.type != IP.OPEN) {
+    console.log("ERROR: Received non OPEN bracket");
+    console.log(bracket);
+    return;
+  }
+  this.dropIP(bracket);
+
+  writeFile(runtime, this, fileDescriptor, inPort);
+
+  fs.closeSync(fileDescriptor);
+};
+
+function writeFile(runtime, proc, fileDescriptor, inPort) {
+  do {
+    var inIP = inPort.receive();
+    if(inIP.type == IP.NORMAL) {
+      var writeResult = runtime.runAsyncCallback(writeData(fileDescriptor, inIP.contents));
+      if (writeResult[0]) {
+        console.error(writeResult[0]);
+        return;
+      }
+      if(writeResult[1] !== 1) {
+        console.error("Insufficient data written!");
+        return;
+      }
+    }
+    proc.dropIP(inIP);
+  } while (inIP.type != IP.CLOSE);
+}
+
+function openFile(path, flags) {
+  return function (done) {
+    fs.open(path, flags, function (err, fd) {
+      done([err, fd]);
+    });
+  }
+}
+
+function writeData(fd, byte) {
+  return function (done) {
+    var writeBuffer = new Buffer(1);
+    writeBuffer[0] = byte;
+    fs.write(fd, writeBuffer, 0, 1, null, function(err, written) {
+      done([err, written]);
+    });
+  }
+}
+

--- a/components/bwriter.js
+++ b/components/bwriter.js
@@ -7,7 +7,7 @@
  */
 
 var fs = require('fs');
-var IP = require('jsfbp/core/IP');
+var IP = require('../core/IP');
 var trace = require('../core/trace');
 
 module.exports = function reader(runtime) {

--- a/core/trace.js
+++ b/core/trace.js
@@ -8,10 +8,9 @@ module.exports = function(message) {
   if(global.trace) {
     if (Fiber.current) {
       var proc = Fiber.current.fbpProc;
-      console.log(proc.name + ' ' + message);
-
+      console.log("<"+proc.name+">" + ' ' + message);
     } else {
-      console.log("NOPROC: " + message);
+      console.log("<null>: " + message);
     }
   }
 

--- a/test/components/breader.js
+++ b/test/components/breader.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var fbp = require('../..');
+
+describe('breader', function () {
+  it('should read a file and output its contents as bytes', function (done) {
+    var network = new fbp.Network();
+
+    var result = [];
+
+    var breader = network.defProc('./components/breader.js');
+    var receiver = network.defProc(MockReceiver.generator(result));
+
+    network.initialize(breader, 'FILE', __dirname+'/hello-world.txt');
+    network.connect(breader, 'OUT', receiver, 'IN');
+
+    var fiberRuntime = new fbp.FiberRuntime();
+    network.run(fiberRuntime, {trace: false}, function() {
+      expect(result).to.deep.equal([72, 101, 108, 108, 111, 0x20, 87, 111, 114, 108, 100, 0x0A]);
+      done();
+    });
+  });
+});

--- a/test/components/bwriter.js
+++ b/test/components/bwriter.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var fbp = require('../..');
+var fs = require('fs');
+
+describe('bwriter', function () {
+  it('should write incoming IPs to a file', function (done) {
+    var network = new fbp.Network();
+
+    var sender = network.defProc(MockSender.generator(["IP.OPEN",
+      71,
+      111,
+      111,
+      100,
+      98,
+      121,
+      101,
+      0x20,
+      87,
+      111,
+      114,
+      108,
+      100,
+      0x0A
+    ,"IP.CLOSE"]));
+    var writer = network.defProc('./components/bwriter.js');
+    //var receiver = network.defProc('./components/recvr');
+
+    network.initialize(writer, 'FILE', __dirname+'/goodbye-world.txt');
+    //network.connect(sender, 'OUT', receiver, 'IN');
+    network.connect(sender, 'OUT', writer, 'IN');
+
+    network.run(new fbp.FiberRuntime(), {trace: false}, function () {
+      fs.readFile(__dirname+'/goodbye-world.txt', 'utf-8', function(err, data) {
+        if(err) {
+          return done(err);
+        }
+        expect(data).to.equal("Goodbye World\n");
+        done();
+      });
+    });
+  });
+});

--- a/test/components/hello-world.txt
+++ b/test/components/hello-world.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/test/mocks/MockSender.js
+++ b/test/mocks/MockSender.js
@@ -1,3 +1,5 @@
+var IP = require('../../core/IP');
+
 var MockSenderGenerator = function (inputArray) {
   initByPort = false;
   if(!inputArray) {
@@ -14,7 +16,12 @@ var MockSenderGenerator = function (inputArray) {
     var outport = this.openOutputPort('OUT');
     var proc = this;
     inputArray.forEach(function (item) {
-      outport.send(proc.createIP(item));
+      if(item === "IP.OPEN" || item === "IP.CLOSE") {
+        var bracket = item.split('.')[1];
+        outport.send(proc.createIPBracket(IP[bracket]));
+      } else {
+        outport.send(proc.createIP(item));
+      }
     });
   };
 };


### PR DESCRIPTION
While I was working on an implementation of LZW compression, I ended up creating a complementary pair of read/write components for reading and writing bytes from/to a file.

In particular, I implemented these in a 'stream' way. By this, I mean that IPs start flowing *as* the file is read, rather than after the whole file is read. Ditto for writing.

- created binary reader and writer components for reading and writing streams of bytes
- added relevant testing
- small tweak to trace to better highlight process name
- small tweak to MockSender to support sending bracket IPs