### PR TITLE
Centralize yielding

### DIFF
--- a/core/InputPort.js
+++ b/core/InputPort.js
@@ -41,11 +41,7 @@ InputPort.prototype.receive = function () {
         trace('recv EOS from ' + this.name);
         return null;
       }
-      proc.status = ProcessStatus.WAITING_TO_RECEIVE;
-      proc.yielded = true;
-      Fiber.yield();
-      proc.status = ProcessStatus.ACTIVE;
-      proc.yielded = false;
+      proc.yield(ProcessStatus.WAITING_TO_RECEIVE);
     }
     else
       break;

--- a/core/OutputPort.js
+++ b/core/OutputPort.js
@@ -40,11 +40,7 @@ OutputPort.prototype.send = function (ip) {
       this._runtime.pushToQueue(conn.down);  
     }
     if (conn.usedslots == conn.array.length) {
-      proc.status = ProcessStatus.WAITING_TO_SEND;
-      proc.yielded = true;
-      Fiber.yield();
-      //proc.status = ProcessStatus.ACTIVE;
-      proc.yielded = false;
+      proc.yield(ProcessStatus.WAITING_TO_SEND, ProcessStatus.WAITING_TO_SEND);
     }
     else {
       break;

--- a/core/Process.js
+++ b/core/Process.js
@@ -141,7 +141,7 @@ Process.prototype.openOutputPortArray = function (name) {
 
 /**
  * Yield the fiber that is running this process
- * 
+ *
  * @param preStatus Process status will be set to this before yielding. If not set or set to `null`, the status is not changed
  * @param postStatus Process status will be set to this after yielding. If not set, the status will be changed to ACTIVE
  */
@@ -150,7 +150,7 @@ Process.prototype.yield = function (preStatus, postStatus) {
     this.status = preStatus;
   }
   this.yielded = true;
-  trace("Yielding with: " + Enum.__lookup(preStatus));
+  trace("Yielding with: " + Process.Status.__lookup(preStatus));
   Fiber.yield();
   if(postStatus !== undefined) {
     this.status = postStatus

--- a/core/Process.js
+++ b/core/Process.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var Enum = require('./utils').Enum
+var Fiber = require('fibers')
+  , Enum = require('./utils').Enum
   , IP = require('./IP')
   , trace = require('./trace');
 
@@ -50,7 +51,7 @@ Process.prototype.createIPBracket = function (bktType, x) {
   this.ownedIPs++;
   ip.owner = this;
   trace("Bracket IP created: " + ["", "OPEN", "CLOSE"][ip.type] + ", " + ip.contents);
-  
+
   return ip;
 };
 
@@ -136,4 +137,19 @@ Process.prototype.openOutputPortArray = function (name) {
   }
 
   return array;
+};
+
+Process.prototype.yield = function (preStatus, postStatus) {
+  if(preStatus !== undefined || preStatus !== null) {
+    this.status = preStatus;
+  }
+  this.yielded = true;
+  trace("Yielding with: " + Enum.__lookup(preStatus));
+  Fiber.yield();
+  if(postStatus !== undefined) {
+    this.status = postStatus
+  } else {
+    this.status = Process.Status.ACTIVE;
+  }
+  this.yielded = false;
 };

--- a/core/Process.js
+++ b/core/Process.js
@@ -139,6 +139,12 @@ Process.prototype.openOutputPortArray = function (name) {
   return array;
 };
 
+/**
+ * Yield the fiber that is running this process
+ * 
+ * @param preStatus Process status will be set to this before yielding. If not set or set to `null`, the status is not changed
+ * @param postStatus Process status will be set to this after yielding. If not set, the status will be changed to ACTIVE
+ */
 Process.prototype.yield = function (preStatus, postStatus) {
   if(preStatus !== undefined || preStatus !== null) {
     this.status = preStatus;

--- a/core/utils.js
+++ b/core/utils.js
@@ -66,14 +66,7 @@ module.exports.findInputPortElementWithData = function (array) {
       return inportWitData.inportElementWithData;
     }
 
-    proc.status = ProcessStatus.WAITING_TO_FIPE;
-    proc.yielded = true;
-    trace('findIPE_with_data: susp');
-
-    Fiber.yield();
-    proc.status = ProcessStatus.ACTIVE;
-    proc.yielded = false;
-    trace('findIPE_with_data: resume');
+    proc.yield(ProcessStatus.WAITING_TO_FIPE);
   }
 };
 


### PR DESCRIPTION
I refactored some code to centralize the following pattern

```
proc.status = ProcessStatus.XXX;
proc.yielded = true;		
Fiber.yield();		
proc.status = ProcessStatus.YYY;		
proc.yielded = false;
```

I think it helps make sure that these steps are consistently applied in the system.