### PR TITLE
repl component should replicate brackets as well as normal IPs

### DIFF
--- a/components/repl.js
+++ b/components/repl.js
@@ -13,7 +13,7 @@ module.exports = function repl() {
       if(ip.type === this.IPTypes.NORMAL) {
         array[i].send(this.createIP(ip.contents));
       } else {
-        array[i].send(this.createIPBracket(ip.type));
+        array[i].send(this.createIPBracket(ip.type, ip.contents));
       }
     }
     this.dropIP(ip);

--- a/components/repl.js
+++ b/components/repl.js
@@ -10,7 +10,11 @@ module.exports = function repl() {
       break;
     }
     for (var i = 0; i < array.length; i++) {
-      array[i].send(this.createIP(ip.contents));
+      if(ip.type === this.IPTypes.NORMAL) {
+        array[i].send(this.createIP(ip.contents));
+      } else {
+        array[i].send(this.createIPBracket(ip.type));
+      }
     }
     this.dropIP(ip);
   }

--- a/core/Process.js
+++ b/core/Process.js
@@ -71,7 +71,7 @@ Process.prototype.createIPBracket = function (bktType, x) {
   ip.type = bktType;
   this.ownedIPs++;
   ip.owner = this;
-  trace("Bracket IP created: " + ["", "OPEN", "CLOSE"][ip.type] + ", " + ip.contents);
+  trace("Bracket IP created: " + IP.Types.__lookup(ip.type) + ", " + ip.contents);
 
   return ip;
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
+var IP = require('./core/IP');
 module.exports = {
   Network: require('./core/Network'),
-  FiberRuntime: require('./core/runtimes/FiberRuntime')
+  FiberRuntime: require('./core/runtimes/FiberRuntime'),
+  IPTypes: IP.Types
 };

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,6 +6,7 @@
     "expect": false,
     "MockSender": false,
     "MockReceiver": false,
+    "TypeReceiver": false,
     "TestFiber": false
   }
 }

--- a/test/components/repl.js
+++ b/test/components/repl.js
@@ -45,7 +45,5 @@ describe('repl', function () {
       expect(result2).to.deep.equal([fbp.IPTypes.OPEN, fbp.IPTypes.NORMAL, fbp.IPTypes.NORMAL, fbp.IPTypes.NORMAL, fbp.IPTypes.CLOSE]);
       done();
     });
-
-
   })
 });

--- a/test/components/repl.js
+++ b/test/components/repl.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var fbp = require('../..');
+
+describe('repl', function () {
+  it('should replicate multiple IPs', function (done) {
+    var network = new fbp.Network();
+
+    var result1 = [];
+    var result2 = [];
+
+    var sender = network.defProc(MockSender.generator([1, 2, 3, 4, 5]), "sender");
+    var repl = network.defProc('./components/repl.js', "repl");
+    var receiver1 = network.defProc(MockReceiver.generator(result1), "receiver1");
+    var receiver2 = network.defProc(MockReceiver.generator(result2), "receiver2");
+
+    network.connect(sender, 'OUT', repl, 'IN');
+    network.connect(repl, 'OUT[0]', receiver1, 'IN');
+    network.connect(repl, 'OUT[1]', receiver2, 'IN');
+
+    network.run(new fbp.FiberRuntime(), {trace: false}, function () {
+      expect(result1).to.deep.equal([1, 2, 3, 4, 5]);
+      expect(result2).to.deep.equal([1, 2, 3, 4, 5]);
+      done();
+    });
+  });
+
+  it('should replicate brackets', function (done) {
+    var network = new fbp.Network();
+
+    var result1 = [];
+    var result2 = [];
+
+    var sender = network.defProc(MockSender.generator(["IP.OPEN", 7, 6, 5, "IP.CLOSE"]), 'sender');
+    var repl = network.defProc('./components/repl.js', "repl");
+    var receiver1 = network.defProc(MockReceiver.generator(result1), "receiver1");
+    var receiver2 = network.defProc(TypeReceiver.generator(result2), "receiver2");
+
+    network.connect(sender, 'OUT', repl, 'IN');
+    network.connect(repl, 'OUT[0]', receiver1, 'IN');
+    network.connect(repl, 'OUT[1]', receiver2, 'IN');
+
+    network.run(new fbp.FiberRuntime(), {trace: false}, function () {
+      expect(result1).to.deep.equal([7, 6, 5]);
+      expect(result2).to.deep.equal([fbp.IPTypes.OPEN, fbp.IPTypes.NORMAL, fbp.IPTypes.NORMAL, fbp.IPTypes.NORMAL, fbp.IPTypes.CLOSE]);
+      done();
+    });
+
+
+  })
+});

--- a/test/mocks/MockReceiver.js
+++ b/test/mocks/MockReceiver.js
@@ -20,7 +20,7 @@ var MockReceiverGenerator = function (outputArray) {
   return MockReceiver;
 };
 
-MockReceiver = MockReceiverGenerator();
+var MockReceiver = MockReceiverGenerator();
 MockReceiver.generator = MockReceiverGenerator;
 
 

--- a/test/mocks/TypeReceiver.js
+++ b/test/mocks/TypeReceiver.js
@@ -1,0 +1,28 @@
+/*
+ * Receives IPs and records their types
+ */
+var TypeReceiverGenerator = function (outputArray) {
+  if(!outputArray) {
+    outputArray = [];
+  }
+  var TypeReceiver = function () {
+    var inport = this.openInputPort('IN');
+    var ip;
+    while ((ip = inport.receive()) !== null) {
+      outputArray.push(ip.type);
+
+      this.dropIP(ip);
+    }
+  };
+
+  TypeReceiver.getResult = function() {
+    return outputArray;
+  };
+  return TypeReceiver;
+};
+
+var TypeReceiver = TypeReceiverGenerator();
+TypeReceiver.generator = TypeReceiverGenerator;
+
+
+module.exports = TypeReceiver;

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -9,6 +9,8 @@ global.expect = chai.expect;
 global.MockSender = require('./mocks/MockSender');
 
 global.MockReceiver = require('./mocks/MockReceiver');
+global.TypeReceiver = require('./mocks/TypeReceiver');
+
 
 global.TestFiber = function(action) {
   Fiber(function() {


### PR DESCRIPTION
I discovered that the repl component does not replicate bracket IPs. It seems like it should.

If you agree, this is the PR for you!

If not, please let me know and let me know the rationale - I'd be curious